### PR TITLE
[SH1106] - fixed wrong width and column in display function

### DIFF
--- a/src/cyclop_plus/libraries/Adafruit_SH1106/Adafruit_SH1106.cpp
+++ b/src/cyclop_plus/libraries/Adafruit_SH1106/Adafruit_SH1106.cpp
@@ -507,9 +507,9 @@ void Adafruit_SH1106::display(void) {
     //height >>= 3;
     //width >>= 3;
 	byte height=64;
-	byte width=132; 
+	byte width=128;
 	byte m_row = 0;
-	byte m_col = 2;
+	byte m_col = 0;
 	
 	
 	height >>= 3;


### PR DESCRIPTION
Just played around with an 0,96" OLED based on SH1106 display (bought this before i realised you had a minimOSD solution available as well ;) ).

There was a corruption when i added a test sketch with your logo on my arduino nano. This pull request fixes this.

Corrupted logo before (see the garbage at column 2):

https://www.dropbox.com/s/6jurxjxnjt8csfz/sh1106_corruption.jpg?dl=0

And here with the bugfix applied:

https://www.dropbox.com/s/ermmt0xhbo77824/sh1106_fine.jpg?dl=0

